### PR TITLE
Add parameter to turn off UKT import and export

### DIFF
--- a/patientview/src/main/java/com/worthsoln/patientview/parser/ResultParser.java
+++ b/patientview/src/main/java/com/worthsoln/patientview/parser/ResultParser.java
@@ -1,6 +1,5 @@
 package com.worthsoln.patientview.parser;
 
-import com.worthsoln.ibd.Ibd;
 import com.worthsoln.ibd.model.Allergy;
 import com.worthsoln.ibd.model.MyIbd;
 import com.worthsoln.ibd.model.Procedure;
@@ -26,7 +25,7 @@ import java.util.Map;
 
 public class ResultParser {
 
-    public static final SimpleDateFormat IMPORT_DATE_FORMAT = new SimpleDateFormat("yyyy-dd-MM");
+    public static final SimpleDateFormat IMPORT_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
 
     private ArrayList<TestResult> testResults = new ArrayList<TestResult>();
     private ArrayList<TestResultDateRange> dateRanges = new ArrayList<TestResultDateRange>();

--- a/patientview/src/test/resources/A_00794_1234567890.gpg.xml
+++ b/patientview/src/test/resources/A_00794_1234567890.gpg.xml
@@ -45,8 +45,8 @@
             <surgicalhistory>Other procedure - please specify, subtotal colcectomy, ileo-rectal anastomosis
             </surgicalhistory>
             <vaccinationrecord>Previous history of chicken pox, Previous TB (BCG) vaccination</vaccinationrecord>
-            <colonoscopysurveillance>01-08-2017</colonoscopysurveillance>
-            <bmdexam>2013-08-08</bmdexam>
+            <colonoscopysurveillance>2012-05-31</colonoscopysurveillance>
+            <bmdexam>2013-02-22</bmdexam>
             <namedconsultant>Dr Lal</namedconsultant>
             <ibdnurse>Cath Stansfield, Justine Newberry</ibdnurse>
         </clinicaldetails>

--- a/patientview/src/test/resources/rm301_1244_9876543210.xml
+++ b/patientview/src/test/resources/rm301_1244_9876543210.xml
@@ -48,8 +48,8 @@
             <surgicalhistory>Other procedure - please specify, subtotal colcectomy, ileo-rectal anastomosis
             </surgicalhistory>
             <vaccinationrecord>Previous history of chicken pox, Previous TB (BCG) vaccination</vaccinationrecord>
-            <colonoscopysurveillance>01-08-2017</colonoscopysurveillance>
-            <bmdexam>2013-08-08</bmdexam>
+            <colonoscopysurveillance>2017-08-29</colonoscopysurveillance>
+            <bmdexam>2013-03-30</bmdexam>
             <namedconsultant>Dr Lal</namedconsultant>
             <ibdnurse>Cath Stansfield, Justine Newberry</ibdnurse>
         </clinicaldetails>


### PR DESCRIPTION
To correct date formats in  ResultParser and in the two test xml files. All dates will come in as yyyy-MM-dd (or yyyy-MM-ddThh-mm-ss)
