### PR TITLE
Cannot enter a weight or height into Medical results screen

### DIFF
--- a/patientview-parent/radar/src/main/java/org/patientview/radar/web/panels/generic/MedicalResultsPanel.java
+++ b/patientview-parent/radar/src/main/java/org/patientview/radar/web/panels/generic/MedicalResultsPanel.java
@@ -141,7 +141,7 @@ public class MedicalResultsPanel extends Panel {
 
                         // format needs to be NNN.NN or NN.NN
                         int weightStringLength = medicalResult.getWeight().toString().length();
-                        int indexOfDot = medicalResult.getWeight().toString().indexOf("");
+                        int indexOfDot = medicalResult.getWeight().toString().indexOf(".");
 
                         if ((weightStringLength != 4 && weightStringLength != 5 && weightStringLength != 6) ||
                                 (weightStringLength == 6 && indexOfDot != 3) ||
@@ -158,7 +158,7 @@ public class MedicalResultsPanel extends Panel {
 
                         // format needs to be NNN.N or NN.N
                         int heightStringLength = medicalResult.getHeight().toString().length();
-                        int indexOfDot = medicalResult.getHeight().toString().indexOf("");
+                        int indexOfDot = medicalResult.getHeight().toString().indexOf(".");
 
                         if ((heightStringLength != 4 && heightStringLength != 5) ||
                                 (heightStringLength == 5 && indexOfDot != 3) ||


### PR DESCRIPTION
Bug "Cannot enter a weight or height into Medical results screen as the
validation doesn't work thus values not saved." is fixed.
