### PR TITLE
138-PV/Radar-Superadmin-adds-generic-Radar-group

### DIFF
--- a/patientview-parent/patientview/src/conf/struts-config.xml
+++ b/patientview-parent/patientview/src/conf/struts-config.xml
@@ -918,7 +918,7 @@
                 input="input"
                 scope="request">
             <forward name="input" path="/control/unit_add_input.jsp"/>
-            <forward name="success" path="/control/unit_add_input.jsp"/>
+            <forward name="success" path="/control/unit_list.jsp"/>
         </action>
 
         <action path="/control/radarGroupAdd"
@@ -927,7 +927,7 @@
                 input="input"
                 scope="request">
             <forward name="input" path="/control/radar_group_add_input.jsp"/>
-            <forward name="success" path="/control/radar_group_add_input.jsp"/>
+            <forward name="success" path="/control/unit_list.jsp"/>
         </action>
 
 
@@ -956,7 +956,7 @@
                 input="input"
                 scope="request">
             <forward name="input" path="/control/unit_edit.jsp"/>
-            <forward name="success" path="/control/unit_edit.jsp"/>
+            <forward name="success" path="/control/unit_list.jsp"/>
         </action>
 
         <action path="/control/radarGroupEdit"
@@ -973,7 +973,7 @@
                 input="input"
                 scope="request">
             <forward name="input" path="/control/radar_group_edit.jsp"/>
-            <forward name="success" path="/control/radar_group_edit.jsp"/>
+            <forward name="success" path="/control/unit_list.jsp"/>
         </action>
 
         <action path="/control/unitPatientsUnitSelect"

--- a/patientview-parent/patientview/src/conf/validation.xml
+++ b/patientview-parent/patientview/src/conf/validation.xml
@@ -228,6 +228,21 @@
             <field property="name" depends="required">
                 <msg key="name.required" name="required"/>
             </field>
+            <field property="shortname" depends="required">
+                <msg key="shortname.required" name="required"/>
+            </field>
+            <field property="renaladminname" depends="required">
+                <msg key="adminname.required" name="required"/>
+            </field>
+            <field property="renaladminphone" depends="required">
+                <msg key="adminphone.required" name="required"/>
+            </field>
+            <field property="renaladminemail" depends="required">
+                <msg key="adminemail.required" name="required"/>
+            </field>
+            <field property="renaladminemail" depends="email">
+                <msg key="email.valid" name="email"/>
+            </field>
         </form>
         <form name="/control/radarGroupUpdate">
             <field property="unitcode" depends="required">
@@ -235,6 +250,21 @@
             </field>
             <field property="name" depends="required">
                 <msg key="name.required" name="required"/>
+            </field>
+            <field property="shortname" depends="required">
+                <msg key="shortname.required" name="required"/>
+            </field>
+            <field property="renaladminname" depends="required">
+                <msg key="adminname.required" name="required"/>
+            </field>
+            <field property="renaladminphone" depends="required">
+                <msg key="adminphone.required" name="required"/>
+            </field>
+            <field property="renaladminemail" depends="required">
+                <msg key="adminemail.required" name="required"/>
+            </field>
+            <field property="renaladminemail" depends="email">
+                <msg key="email.valid" name="email"/>
             </field>
         </form>
         <form name="/control/patientAdd">

--- a/patientview-parent/patientview/src/main/java/org/patientview/patientview/logon/RadarGroupUsersAction.java
+++ b/patientview-parent/patientview/src/main/java/org/patientview/patientview/logon/RadarGroupUsersAction.java
@@ -41,7 +41,7 @@ public class RadarGroupUsersAction extends Action {
             throws Exception {
         if (LegacySpringUtils.getUserManager().getLoggedInUserRole().equals("superadmin")) {
             List items = LegacySpringUtils.getUnitManager().getAdminsUnits(true);
-            request.getSession().setAttribute("units", items);
+            request.setAttribute("units", items);
         } else {
             UnitUtils.putRelevantUnitsInRequest(request);
         }

--- a/patientview-parent/patientview/src/main/java/org/patientview/patientview/unit/UnitAddAction.java
+++ b/patientview-parent/patientview/src/main/java/org/patientview/patientview/unit/UnitAddAction.java
@@ -33,6 +33,7 @@ import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
 import org.patientview.patientview.logon.LogonUtils;
+import java.util.List;
 
 public class UnitAddAction extends Action {
 
@@ -42,8 +43,22 @@ public class UnitAddAction extends Action {
 
         Unit unit = new Unit();
         UnitUtils.buildUnit(unit, form);
+        //a new unitcode doesn't exist,
+        // so any user doesn't have SecurityConfig.UNIT_ACCESS permission to check this code
+        // Unit existedUnit = LegacySpringUtils.getUnitManager().get(unit.getUnitcode());
+        boolean duplicate = LegacySpringUtils.getUnitManager().checkDuplicateUnitCode(unit.getUnitcode());
+        if (duplicate) {
+            request.setAttribute("UnitExisted", true);
+            return mapping.findForward("input");
+        }
         LegacySpringUtils.getUnitManager().save(unit);
-        request.setAttribute("unit", unit);
+
+        boolean isRadarGroup = false;
+        if ("radargroup".equals(unit.getSourceType())) {
+            isRadarGroup = true;
+        }
+        List items = LegacySpringUtils.getUnitManager().getAdminsUnits(isRadarGroup);
+        request.setAttribute("units", items);
 
         return LogonUtils.logonChecks(mapping, request);
     }

--- a/patientview-parent/patientview/src/main/java/org/patientview/patientview/unit/UnitUpdateAction.java
+++ b/patientview-parent/patientview/src/main/java/org/patientview/patientview/unit/UnitUpdateAction.java
@@ -27,6 +27,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.patientview.patientview.model.Unit;
+import org.patientview.patientview.model.User;
 import org.patientview.utils.LegacySpringUtils;
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.struts.action.Action;
@@ -34,6 +35,8 @@ import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
 import org.patientview.patientview.logon.LogonUtils;
+
+import java.util.List;
 
 public class UnitUpdateAction extends Action {
 
@@ -44,7 +47,21 @@ public class UnitUpdateAction extends Action {
         Unit unit = LegacySpringUtils.getUnitManager().get(BeanUtils.getProperty(form, "unitcode"));
         UnitUtils.buildUnit(unit, form);
         LegacySpringUtils.getUnitManager().save(unit);
-        request.setAttribute("unit", unit);
+
+        boolean isRadarGroup = false;
+        if ("radargroup".equals(unit.getSourceType())) {
+            isRadarGroup = true;
+        }
+
+        List items;
+        User user = LegacySpringUtils.getUserManager().getLoggedInUser();
+        if (LegacySpringUtils.getUserManager().getCurrentSpecialtyRole(user).equals("superadmin")) {
+            items = LegacySpringUtils.getUnitManager().getAdminsUnits(isRadarGroup);
+        } else {
+            items = LegacySpringUtils.getUnitManager().getLoggedInUsersUnits();
+        }
+
+        request.setAttribute("units", items);
 
         return LogonUtils.logonChecks(mapping, request);
     }

--- a/patientview-parent/patientview/src/main/java/org/patientview/service/UnitManager.java
+++ b/patientview-parent/patientview/src/main/java/org/patientview/service/UnitManager.java
@@ -54,6 +54,13 @@ public interface UnitManager {
      */
     Unit get(String unitCode);
 
+    /**
+     * a new unitcode doesn't exist, so any user doesn't have SecurityConfig.UNIT_ACCESS permission to check this code
+     * @param unitCode String
+     * @return true if duplicate
+     */
+    boolean checkDuplicateUnitCode(String unitCode);
+
     void save(Unit unit);
 
     List<Unit> getAllDisregardingSpeciality(boolean sortByName);

--- a/patientview-parent/patientview/src/main/java/org/patientview/service/impl/UnitManagerImpl.java
+++ b/patientview-parent/patientview/src/main/java/org/patientview/service/impl/UnitManagerImpl.java
@@ -87,6 +87,11 @@ public class UnitManagerImpl implements UnitManager {
     }
 
     @Override
+    public boolean checkDuplicateUnitCode(String unitCode) {
+        return unitDao.get(unitCode, securityUserManager.getLoggedInSpecialty()) != null;
+    }
+
+    @Override
     public List<Unit> getAllDisregardingSpeciality(boolean sortByName) {
         return unitDao.getAll(true);
     }

--- a/patientview-parent/patientview/src/main/resources/Messages.properties
+++ b/patientview-parent/patientview/src/main/resources/Messages.properties
@@ -154,3 +154,10 @@ data.exist={0} already exists.
 
 # success message
 success.message={0} was updated successfully.
+
+#unit
+shortname.required=Please supply a Short Name
+adminname.required=Please supply a Admin Name
+adminphone.required=Please supply a Admin Phone
+adminemail.required=Please supply a Admin Email
+unitcode.duplicated=Please re-enter a different Code.

--- a/patientview-parent/patientview/src/main/webapp/body/control/radar_group_add_input.jsp
+++ b/patientview-parent/patientview/src/main/webapp/body/control/radar_group_add_input.jsp
@@ -1,5 +1,7 @@
 <%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>
+<%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
 <%@ taglib uri="http://struts.apache.org/tags-logic" prefix="logic" %>
+
 <%--
   ~ PatientView
   ~
@@ -32,6 +34,11 @@
 <html:errors />
 
 <html:form action="/control/radarGroupAdd">
+
+    <logic:present name="UnitExisted">
+        <bean:message key="errors.header"/><bean:message key="errors.prefix"/><bean:message
+            key="unitcode.duplicated"/><bean:message key="errors.suffix"/><bean:message key="errors.footer"/>
+    </logic:present>
 
   <table cellpadding="3" >
 

--- a/patientview-parent/patientview/src/main/webapp/body/control/unit_add_input.jsp
+++ b/patientview-parent/patientview/src/main/webapp/body/control/unit_add_input.jsp
@@ -1,4 +1,5 @@
 <%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>
+<%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
 <%@ taglib uri="http://struts.apache.org/tags-logic" prefix="logic" %>
 <%--
   ~ PatientView
@@ -32,6 +33,11 @@
 <html:errors />
 
 <html:form action="/control/unitAdd">
+
+<logic:present name="UnitExisted">
+    <bean:message key="errors.header"/><bean:message key="errors.prefix"/><bean:message
+        key="unitcode.duplicated"/><bean:message key="errors.suffix"/><bean:message key="errors.footer"/>
+</logic:present>
 
   <table cellpadding="3" >
 


### PR DESCRIPTION
On successful addition go back to list of Radar units. Otherwise the
form is still filled in and someone will press "Add" button again
thinking that it hasn't worked.
Needs validation on the form: all fields are mandatory, email must be
well formed.
If you add a new radar group which has a duplicate unitcode of an
existing group then a 404 error appears. Need to check for this and give
a warning on the page so the user can correct it.
